### PR TITLE
Improved Chip Tower Animation and other opinionated changes

### DIFF
--- a/galdur.lua
+++ b/galdur.lua
@@ -390,6 +390,8 @@ function get_stake_sprite_in_area(_stake, _scale, _area)
                     Sprite.draw_shader(_sprite, 'voucher', nil, _sprite.ARGS.send_to_shader)
                 else
                     Sprite.draw_self(_sprite, G.C.L_BLACK) 
+                    -- Sprite.draw_shader(_sprite, 'dissolve')
+                    Sprite.draw_shader(_sprite, 'voucher', nil, _sprite.ARGS.send_to_shader)
                 end
             else
                 if Galdur.config.stake_colour == 2 then
@@ -397,6 +399,8 @@ function get_stake_sprite_in_area(_stake, _scale, _area)
                     Sprite.draw_shader(_sprite, 'voucher', nil, _sprite.ARGS.send_to_shader)
                 else
                     Sprite.draw_self(_sprite, G.C.L_BLACK) 
+                    -- Sprite.draw_shader(_sprite, 'dissolve')
+                    Sprite.draw_shader(_sprite, 'voucher', nil, _sprite.ARGS.send_to_shader)
                 end
             end
         end

--- a/galdur.lua
+++ b/galdur.lua
@@ -31,6 +31,12 @@ SMODS.Atlas({ -- art by nekojoe
     py = 29
 })
 
+DECKS_PER_ROW = 4
+DECK_ROWS_PER_PAGE = 2 -- Does nothing atm
+DECKS_PER_PAGE = DECKS_PER_ROW * 2
+STAKES_PER_ROW = 8
+STAKE_ROWS_PER_PAGE = 3
+STAKES_PER_PAGE = STAKES_PER_ROW * STAKE_ROWS_PER_PAGE
 
 -- Function Hooks
 local card_stop_hover = Card.stop_hover
@@ -73,7 +79,7 @@ function Card:hover()
         if badges.nodes.mod_set then badges.nodes.mod_set = nil end
 
         self.config.h_popup = {n=G.UIT.C, config={align = "cm", padding=0.1}, nodes={
-            (self.params.deck_select > 6 and {n=col, config={align='cm', padding=0.1}, nodes = tooltips} or {n=G.UIT.R}),
+            (self.params.deck_select > DECKS_PER_ROW and {n=col, config={align='cm', padding=0.1}, nodes = tooltips} or {n=G.UIT.R}),
             {n=col, config={align=(self.params.deck_preview and 'bm' or 'cm')}, nodes = {
                 {n=G.UIT.C, config={align = "cm", minh = 1.5, r = 0.1, colour = G.C.L_BLACK, padding = 0.1, outline=1}, nodes={
                     {n=G.UIT.R, config={align = "cm", r = 0.1, minw = 3, maxw = 4, minh = 0.4}, nodes={
@@ -222,7 +228,7 @@ function generate_deck_card_areas()
         end
     end
     Galdur.run_setup.deck_select_areas = {}
-    for i=1, 12 do
+    for i=1, DECKS_PER_PAGE do
         Galdur.run_setup.deck_select_areas[i] = CardArea(G.ROOM.T.w,G.ROOM.T.h, G.CARD_W, G.CARD_H, 
         {card_limit = 5, type = 'deck', highlight_limit = 0, deck_height = 0.75, thin_draw = 1, deck_select = true, index = i})
     end
@@ -233,7 +239,7 @@ function generate_deck_card_areas_ui()
     local count = 1
     for i=1, 2 do
         local row = {n = G.UIT.R, config = {colour = G.C.LIGHT}, nodes = {}}
-        for j=1, 6 do
+        for j=1, DECKS_PER_ROW do
             if count > #G.P_CENTER_POOLS.Back then return end
             table.insert(row.nodes, {n = G.UIT.O, config = {object = Galdur.run_setup.deck_select_areas[count], r = 0.1, id = "deck_select_"..count}})
             count = count + 1
@@ -247,8 +253,8 @@ function generate_deck_card_areas_ui()
 end
 
 function populate_deck_card_areas(page)
-    local count = 1 + (page - 1) * 12
-    for i=1, 12 do
+    local count = 1 + (page - 1) * DECKS_PER_PAGE
+    for i=1, DECKS_PER_PAGE do
         if count > #G.P_CENTER_POOLS.Back then return end
         local card_number = Galdur.config.reduce and 1 or 10
         for index = 1, card_number do
@@ -300,8 +306,8 @@ end
 function create_deck_page_cycle()
     local options = {}
     local cycle
-    if #G.P_CENTER_POOLS.Back > 12 then
-        local total_pages = math.ceil(#G.P_CENTER_POOLS.Back / 12)
+    if #G.P_CENTER_POOLS.Back > DECKS_PER_PAGE then
+        local total_pages = math.ceil(#G.P_CENTER_POOLS.Back / DECKS_PER_PAGE)
         for i=1, total_pages do
             table.insert(options, localize('k_page')..' '..i..' / '..total_pages)
         end
@@ -337,7 +343,7 @@ function generate_stake_card_areas()
         end
     end
     Galdur.run_setup.stake_select_areas = {}
-    for i=1, 24 do
+    for i=1, STAKES_PER_PAGE do
         Galdur.run_setup.stake_select_areas[i] = CardArea(G.ROOM.T.w * 0.116, G.ROOM.T.h * 0.209, 3.4*14/41, 3.4*14/41, 
         {card_limit = 1, type = 'deck', highlight_limit = 0, stake_select = true})
     end
@@ -346,9 +352,9 @@ end
 function generate_stake_card_areas_ui()
     local stake_ui_element = {}
     local count = 1
-    for i=1, 3 do
+    for i=1, STAKE_ROWS_PER_PAGE do
         local row = {n = G.UIT.R, config = {colour = G.C.LIGHT, padding = 0.1}, nodes = {}}
-        for j=1, 8 do
+        for j=1, STAKES_PER_ROW do
             table.insert(row.nodes, {n = G.UIT.O, config = {object = Galdur.run_setup.stake_select_areas[count], r = 0.1, id = "stake_select_"..count, outline_colour = G.C.YELLOW}})
             count = count + 1
         end
@@ -393,8 +399,8 @@ function get_stake_sprite_in_area(_stake, _scale, _area)
 end
 
 function populate_stake_card_areas(page)
-    local count = 1 + (page - 1) * 24
-    for i=1, 24 do
+    local count = 1 + (page - 1) * STAKES_PER_PAGE
+    for i=1, STAKES_PER_PAGE do
         if count > #G.P_CENTER_POOLS.Stake then return end
         local card = Card(Galdur.run_setup.stake_select_areas[i].T.x,Galdur.run_setup.stake_select_areas[i].T.y, 3.4*14/41, 3.4*14/41,
             Galdur.run_setup.choices.deck.effect.center, Galdur.run_setup.choices.deck.effect.center, {stake_chip = true, stake = count, galdur_selector = true})
@@ -439,7 +445,7 @@ end
 
 function create_stake_page_cycle()
     local options = {}
-    local total_pages = math.ceil(#G.P_CENTER_POOLS.Stake / 24)
+    local total_pages = math.ceil(#G.P_CENTER_POOLS.Stake / STAKES_PER_PAGE)
     for i=1, total_pages do
         table.insert(options, localize('k_page')..' '..i..' / '..total_pages)
     end

--- a/galdur.lua
+++ b/galdur.lua
@@ -355,7 +355,10 @@ end
 function generate_stake_card_areas_ui()
     local stake_ui_element = {}
     local count = 1
-    for i=1, STAKE_ROWS_PER_PAGE do
+
+    -- Assuming no row limit per page, this would be the number of rows the stakes would fill
+    local needed_rows = math.ceil(#G.P_CENTER_POOLS.Stake / STAKES_PER_ROW)
+    for i=1, math.min(needed_rows, STAKE_ROWS_PER_PAGE) do
         local row = {n = G.UIT.R, config = {colour = G.C.LIGHT, padding = 0.1}, nodes = {}}
         for j=1, STAKES_PER_ROW do
             table.insert(row.nodes, {n = G.UIT.O, config = {object = Galdur.run_setup.stake_select_areas[count], r = 0.1, id = "stake_select_"..count, outline_colour = G.C.YELLOW}})

--- a/galdur.lua
+++ b/galdur.lua
@@ -776,6 +776,8 @@ end
 
 Galdur.include_chip_tower = function(animate)
     Galdur.generate_chip_tower()
+    G.E_MANAGER:clear_queue('galdur')
+    Galdur.populating_chip_tower = false
     Galdur.populate_chip_tower(Galdur.run_setup.choices.stake, not animate)
 end
 
@@ -985,7 +987,7 @@ function Galdur.populate_chip_tower(_stake, silent, prev_stake)
                     trigger = 'after',
                     delay = 0.01,
                     func = (function()
-                        if Galdur.run_setup.chip_tower.cards[1] then
+                        if Galdur.run_setup.chip_tower.cards and Galdur.run_setup.chip_tower.cards[1] then
                             Galdur.run_setup.chip_tower.cards[1].ability.discarded = true
                             play_sound('chips2', math.random() * 0.1 + (index + last_shared_index) * 0.1 + 0.6, 0.55)
                             -- Galdur.run_setup.chip_tower.cards[index]:drag({x = 0, y = -20})
@@ -1000,7 +1002,7 @@ function Galdur.populate_chip_tower(_stake, silent, prev_stake)
                     func = (function()
                         remove_all(Galdur.run_setup.chip_tower_holding.cards)
                         Galdur.run_setup.chip_tower_holding.cards = {}
-                        if #Galdur.run_setup.chip_tower.cards <= #applied_stakes then
+                        if Galdur.run_setup.chip_tower.cards and #Galdur.run_setup.chip_tower.cards <= #applied_stakes then
                             Galdur.populating_chip_tower = false
                         end
                         return true
@@ -1038,9 +1040,11 @@ function Galdur.populate_chip_tower(_stake, silent, prev_stake)
                 func = (function()
                     card.children.back.states.visible = true
                     play_sound('chips2', math.random() * 0.1 + 0.1 * index + 0.7, 0.55)
-                    if Galdur.run_setup.chip_tower.cards then Galdur.run_setup.chip_tower:draw_card_from(Galdur.run_setup.chip_tower_holding) end
-                    if #Galdur.run_setup.chip_tower.cards >= #applied_stakes then
-                        Galdur.populating_chip_tower = false
+                    if Galdur.run_setup.chip_tower.cards then 
+                        Galdur.run_setup.chip_tower:draw_card_from(Galdur.run_setup.chip_tower_holding) 
+                        if #Galdur.run_setup.chip_tower.cards >= #applied_stakes then
+                            Galdur.populating_chip_tower = false
+                        end
                     end
                     return true
                 end)
@@ -1052,7 +1056,7 @@ function Galdur.populate_chip_tower(_stake, silent, prev_stake)
                 delay = 0.01,
                 func = (function()
                     card.children.back.states.visible = true
-                    if #Galdur.run_setup.chip_tower.cards >= #applied_stakes then
+                    if Galdur.run_setup.chip_tower.cards and #Galdur.run_setup.chip_tower.cards >= #applied_stakes then
                         Galdur.populating_chip_tower = false
                     end
                     return true

--- a/galdur.lua
+++ b/galdur.lua
@@ -31,9 +31,9 @@ SMODS.Atlas({ -- art by nekojoe
     py = 29
 })
 
-DECKS_PER_ROW = 4
-DECK_ROWS_PER_PAGE = 2 -- Does nothing atm
-DECKS_PER_PAGE = DECKS_PER_ROW * 2
+DECKS_PER_ROW = 6
+DECK_ROWS_PER_PAGE = 2 -- Anything above 2 will be too big for the screen
+DECKS_PER_PAGE = DECKS_PER_ROW * DECK_ROWS_PER_PAGE
 STAKES_PER_ROW = 8
 STAKE_ROWS_PER_PAGE = 3
 STAKES_PER_PAGE = STAKES_PER_ROW * STAKE_ROWS_PER_PAGE
@@ -98,7 +98,7 @@ function Card:hover()
                     }},
                 }}
             }},
-            (self.params.deck_select < 7 and {n=col, config={align=(self.params.deck_preview and 'bm' or 'cm'), padding=0.1}, nodes = tooltips} or {n=G.UIT.R})
+            (self.params.deck_select <= DECKS_PER_ROW and {n=col, config={align=(self.params.deck_preview and 'bm' or 'cm'), padding=0.1}, nodes = tooltips} or {n=G.UIT.R})
             
         }}
         self.config.h_popup_config = self:align_h_popup()
@@ -237,7 +237,7 @@ end
 function generate_deck_card_areas_ui()
     local deck_ui_element = {}
     local count = 1
-    for i=1, 2 do
+    for i=1, DECK_ROWS_PER_PAGE do
         local row = {n = G.UIT.R, config = {colour = G.C.LIGHT}, nodes = {}}
         for j=1, DECKS_PER_ROW do
             if count > #G.P_CENTER_POOLS.Back then return end

--- a/galdur.lua
+++ b/galdur.lua
@@ -67,7 +67,7 @@ function Card:hover()
             for _, center in pairs(info_queue) do
                 local desc = generate_card_ui(center, {main = {},info = {},type = {},name = 'done',badges = badges or {}}, nil, center.set, nil)
                 tooltips[#tooltips + 1] =
-                {n=info_col, config={align = "tm"}, nodes={
+                {n=info_col, config={align = (self.params.deck_select > DECKS_PER_ROW and "bm" or "tm")}, nodes={
                     {n=G.UIT.R, config={align = "cm", colour = lighten(G.C.JOKER_GREY, 0.5), r = 0.1, padding = 0.05, emboss = 0.05}, nodes={
                     info_tip_from_rows(desc.info[1], desc.info[1].name),
                     }}

--- a/galdur.lua
+++ b/galdur.lua
@@ -170,11 +170,11 @@ function Card:click()
         -- Galdur.run_setup.choices.stake = get_deck_win_stake(Galdur.run_setup.choices.deck.effect.center.key)
         Galdur.set_new_deck()
     elseif self.params.stake_chip and not self.params.stake_chip_locked then
-if Galdur.run_setup.choices.stake ~= self.params.stake then
+        if Galdur.run_setup.choices.stake ~= self.params.stake then
             local prev_stake = Galdur.run_setup.choices.stake
-        Galdur.run_setup.choices.stake = self.params.stake
+            Galdur.run_setup.choices.stake = self.params.stake
             -- G.E_MANAGER:clear_queue('galdur')
-        Galdur.populate_chip_tower(self.params.stake, false, prev_stake)
+            Galdur.populate_chip_tower(self.params.stake, false, prev_stake)
         end
     else
         card_click_ref(self)
@@ -389,7 +389,7 @@ function get_stake_sprite_in_area(_stake, _scale, _area)
                     Sprite.draw_shader(_sprite, 'dissolve')
                     Sprite.draw_shader(_sprite, 'voucher', nil, _sprite.ARGS.send_to_shader)
                 else
-                    Sprite.draw_self(_sprite, G.C.L_BLACK) 
+                    Sprite.draw_self(_sprite, G.C.L_BLACK)
                     -- Sprite.draw_shader(_sprite, 'dissolve')
                     Sprite.draw_shader(_sprite, 'voucher', nil, _sprite.ARGS.send_to_shader)
                 end
@@ -398,7 +398,7 @@ function get_stake_sprite_in_area(_stake, _scale, _area)
                     Sprite.draw_shader(_sprite, 'dissolve')
                     Sprite.draw_shader(_sprite, 'voucher', nil, _sprite.ARGS.send_to_shader)
                 else
-                    Sprite.draw_self(_sprite, G.C.L_BLACK) 
+                    Sprite.draw_self(_sprite, G.C.L_BLACK)
                     -- Sprite.draw_shader(_sprite, 'dissolve')
                     Sprite.draw_shader(_sprite, 'voucher', nil, _sprite.ARGS.send_to_shader)
                 end
@@ -719,7 +719,7 @@ function deck_select_page_deck()
     return 
         {n=G.UIT.ROOT, config={align = "tm", minh = 3.8, colour = G.C.CLEAR, padding=0.1}, nodes={
             {n=G.UIT.C, config = {padding = 0.15}, nodes ={   
-                generate_deck_card_areas_ui(), 
+                generate_deck_card_areas_ui(),
                 create_deck_page_cycle(),
             }},
             deck_preview
@@ -935,7 +935,7 @@ function Galdur.generate_chip_tower()
         end
     end
     -- x and y here wont really matter since they'll be placed in a UIBox
-    Galdur.run_setup.chip_tower = CardArea(G.ROOM.T.w * 0.656, G.ROOM.T.y, 3.4*14/41, 3.4*14/41, 
+    Galdur.run_setup.chip_tower = CardArea(G.ROOM.T.w * 0.656, G.ROOM.T.y, 3.4*14/41, 3.4*14/41,
         {type = 'deck', highlight_limit = 0, draw_layers = {'card'}, thin_draw = 1, stake_chips = true})
     Galdur.run_setup.chip_tower_holding = CardArea(G.ROOM.T.w * 0.656, -2*G.CARD_H, 3.4*14/41, 3.4*14/41,
         {type = 'deck', highlight_limit = 0, draw_layers = {'card'}, thin_draw = 1, stake_chips = true})
@@ -958,9 +958,9 @@ function Galdur.populate_chip_tower(_stake, silent, prev_stake)
     local last_shared_index = 0
     silent = silent or false
     if Galdur.run_setup.chip_tower.cards then
-if not prev_stake then
-        remove_all(Galdur.run_setup.chip_tower.cards)
-        Galdur.run_setup.chip_tower.cards = {}
+        if not prev_stake then
+            remove_all(Galdur.run_setup.chip_tower.cards)
+            Galdur.run_setup.chip_tower.cards = {}
         end
         remove_all(Galdur.run_setup.chip_tower_holding.cards)
         Galdur.run_setup.chip_tower_holding.cards = {}


### PR DESCRIPTION
This PR contains a lot of relatively unimportant and opinionated changes, as opposed to important bug fixes or features. I'm leaving this as a draft for now to be able to incorporate any feedback and allow discussion around which of these are fit to be included in the mod properly.

# New Chip Tower Animation

I've modified the `populate_chip_tower()` and `display_chip_tower()` functions so that when selecting stakes, instead of respawning the entire chip tower, it will now add or remove chips dynamically based on the previously selected stake and the new stake.

## Demo of new animation
https://github.com/user-attachments/assets/d4647792-5105-40bc-b484-6ce3eb76e6f2

## Current animation for reference
https://github.com/user-attachments/assets/7a228443-42b2-4303-9c73-10759a80275d

The chip removal animation is achieved by placing the `chip_tower_holding` area above `chip_tower`, and moving the stake from the tower to the tower holding area before removing it (basically reversing how they're added). A `prev_stake` parameter was added to `populate_chip_tower()` to help compare the new and old stakes and decide which chips to remove/add.

## Other small additions in addition to this animation

- SFX of chip falling will increase in pitch the higher the stake is (can be heard in demo video)
- Shiny stakes will now have the voucher effect even while greyed out (this makes the gold stake look gold rather than just yellow)
- Stake selection will now be centered on screen if it fits on one page in less than 3 rows (can be seen in demo video). 
- Added global variables to configure the number of rows per page and objects per row for deck and stake selection. Currently just for dev purposes, but could be added as a setting later if desired.
  - Will not shrink UI to fit screen, so too many rows or too large a row will simply extend beyond the screen.
- Tooltips when hovering over decks in the bottom row will now align with the bottom rather than the top. See below for comparison.
  - This example where one tooltip is much larger than the other is the main annoyance with the old alignment.
![image](https://github.com/user-attachments/assets/94364d6b-abcb-4604-808e-7513fc2123b1)

### Some aspects that could do with improvement or further testing:
- Currently `populate_chip_tower()` needs to make use of a new global variable to track whether the animation is running or not, and prevent further calls to it while running. This prevents changing stake mid-animation and breaking the UI. Better solutions could be possible.
- Has been tested with Cryptid stakes to see if it works with more than 8 stakes. 
  - The long animation will block stake animation, and will be abruptly cut off if 'start' is pressed before it is finished.
  - The increasing pitch of the sound effect gets kind of ridiculous beyond the vanilla stakes.
  - There is a minor issue where going back to deck selection then to stake selection may default to white stake, ignoring the preferred default stake option
- Has been tested with non-linear stakes. It will remove any unneeded stakes without an animation then play the population animation for the new stakes. Could be handled more gracefully.