### PR TITLE
Add pt_BR locs and Random Deck and Sleeve localization support

### DIFF
--- a/galdur.lua
+++ b/galdur.lua
@@ -711,7 +711,7 @@ function deck_select_page_deck()
     local deck_preview = Galdur.display_deck_preview()
     deck_preview.nodes[#deck_preview.nodes+1] = {n = G.UIT.R, config={align = 'cm', padding = 0.15}, nodes = {
         {n=G.UIT.C, config = {maxw = 2.5, minw = 2.5, minh = 0.8, r = 0.1, hover = true, ref_value = 1, button = 'random_deck', colour = Galdur.badge_colour, align = "cm", emboss = 0.1}, nodes = {
-            {n=G.UIT.R, config = {align = 'cm'}, nodes = {{n=G.UIT.T, config={text = "Random Deck", scale = 0.4, colour = G.C.WHITE}}}},
+            {n=G.UIT.R, config = {align = 'cm'}, nodes = {{n=G.UIT.T, config={text = localize('gald_random_deck'), scale = 0.4, colour = G.C.WHITE}}}},
             {n=G.UIT.R, config = {align = 'cm'}, nodes = {{n=G.UIT.C, config={func = 'set_button_pip', focus_args = { button = 'triggerright', set_button_pip = true, offset = {x=-0.2, y = 0.3} }}}}}            
         }}
     }}
@@ -742,7 +742,7 @@ function deck_select_page_stake()
     local deck_preview = Galdur.display_deck_preview()
     deck_preview.nodes[#deck_preview.nodes+1] = {n = G.UIT.R, config={align = 'cm', padding = 0.15}, nodes = {
         {n=G.UIT.C, config = {maxw = 2.5, minw = 2.5, minh = 0.8, r = 0.1, hover = true, ref_value = 1, button = 'random_stake', colour = Galdur.badge_colour, align = "cm", emboss = 0.1}, nodes = {
-            {n=G.UIT.R, config = {align = 'cm'}, nodes = {{n=G.UIT.T, config={text = "Random Stake", scale = 0.4, colour = G.C.WHITE}}}},
+            {n=G.UIT.R, config = {align = 'cm'}, nodes = {{n=G.UIT.T, config={text = localize('gald_random_stake'), scale = 0.4, colour = G.C.WHITE}}}},
             {n=G.UIT.R, config = {align = 'cm'}, nodes = {{n=G.UIT.C, config={func = 'set_button_pip', focus_args = { button = 'triggerright', set_button_pip = true, offset = {x=-0.2, y = 0.3} }}}}}            
         }}
     }}

--- a/localization/default.lua
+++ b/localization/default.lua
@@ -40,6 +40,8 @@ return {
             },
             ["gald_select_deck"] = "Select Deck",
             ["gald_select_stake"] = "Select Stake",
+	    ["gald_random_deck"] = "Random Deck",
+	    ["gald_random_stake"] = "Random Stake",
             ["gald_play"] = "Play",
             ["gald_selected"] = "SELECTED",
             ["gald_locked"] = "Locked",

--- a/localization/pt_BR.lua
+++ b/localization/pt_BR.lua
@@ -1,0 +1,54 @@
+return {
+	["misc"] = {
+		["dictionary"] = {
+			["gald_master"] = "Ativar Galdur",
+            ["gald_use_desc"] = {
+                "Usar o modo de seleção do Galdur"    
+            },
+            ["gald_anim"] = "Ativar animações",
+            ["gald_anim_desc"] = {
+                "Esta opção ativa as animações",
+                "de pré-vizualização do baralho e de apostas"				
+            },
+            ["gald_reduce"] = "Reduzir o tamanho do baralho",
+            ["gald_reduce_desc"] = {
+                "Esta opção reduz o número",
+                "de cartas mostradas na tela"    
+            },
+            ["gald_stake_colour"] = "Esmaecer Apostas",
+            ["gald_stake_colour_options"] = {
+                "Esmaecer as não-completadas",    
+                "Esmaecer as completadas",
+            },
+            ["gald_stake_colour_desc"] = {
+                "Escolha que tipo de aposta é",
+                "esmaecida na tela de seleção de aposta"
+            },
+            ["gald_stake_select"] = "Selecionar Aposta",
+            ["gald_stake_select_options"] = {
+                "Última jogada",    
+                "Próxima desbloqueada",
+                "Aposta Branca"
+            },
+            ["gald_stake_select_desc"] = {
+                "Escolha qual aposta é selecionada",
+                "por padrão na tela de seleção de aposta"
+            },
+            ["gald_unlock"] = "Desbloquear todas as apostas",
+            ["gald_unlock_desc"] = {
+                "Esta opção lhe permite jogar em qualquer aposta"    
+            },
+            ["gald_select_deck"] = "Baralho",
+            ["gald_select_stake"] = "Aposta",
+			["gald_random_deck"] = "Aleatório",
+			["gald_random_stake"] = "Aleatória",
+            ["gald_play"] = "Jogar",
+            ["gald_selected"] = "SELECIONADO",
+            ["gald_locked"] = "Bloqueado",
+            ["gald_unlock_1"] = "Vença com este baralho na ",
+            ["gald_unlock_and"] = " e ",
+            ["gald_new_page_error"] = "Erro ao adicionar página",
+            ["gald_quick_start"] = "Última tentativa"
+        }
+    }
+}


### PR DESCRIPTION
Hey there, Eremel!

I'm on a quest to translate all of my favorite and essential mods to Brazilian Portuguese. For this mod the only issue was that the text for "Random Deck" and "Random Sleeve" wasn't inside a `localize()` function. So, I've added `['gald_random_deck']` and `['gald_random_sleeve']` to the locs and edited the text in `galdur.lua` to be inside a `localize()` function. This should work, I think.

Anyways, thanks for this glorious mod and be well.