### PR TITLE
Don't add duplicate info_queue tooltips from {T:} elements

### DIFF
--- a/galdur.lua
+++ b/galdur.lua
@@ -1084,7 +1084,16 @@ function populate_info_queue(set, key)
     local loc_target = G.localization.descriptions[set][key]
     for _, lines in ipairs(loc_target.text_parsed) do
         for _, part in ipairs(lines) do
-            if part.control.T then info_queue[#info_queue+1] = G.P_CENTERS[part.control.T] or G.P_TAGS[part.control.T] end
+            if part.control.T then
+                local already_added = false
+                for _, v in ipairs(info_queue) do
+                    if v == G.P_CENTERS[part.control.T] or v == G.P_TAGS[part.control.T] then
+                        already_added = true
+                        break
+                    end
+                end
+                if not already_added then info_queue[#info_queue+1] = G.P_CENTERS[part.control.T] or G.P_TAGS[part.control.T] end
+            end
         end
     end
     return info_queue


### PR DESCRIPTION
This fixes a bug where the info_queue handler can add multiple of the same tooltip when multiple {T:} formatting elements using the same key are present in a description